### PR TITLE
add support for Vercel team id for dns API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ To use this module for the ACME DNS challenge, [configure the ACME issuer in you
     "dns": {
       "provider": {
         "name": "vercel",
-        "api_token": "YOUR_VERCEL_AUTH_API_TOKEN"
+        "auth_api_token": "YOUR_VERCEL_AUTH_API_TOKEN",
+        "team_id": "YOUR_VERCEL_TEAM_ID"
       }
     }
   }
@@ -32,7 +33,10 @@ or with the Caddyfile:
 your.domain.com {
   respond "Hello World"	# replace with whatever config you need...
   tls {
-    dns vercel {env.YOUR_HETZNER_AUTH_API_TOKEN}
+    dns vercel {
+      auth_api_token {env.YOUR_VERCEL_AUTH_API_TOKEN}
+      team_id {env.YOUR_VERCEL_AUTH_API_TOKEN}
+      }
   }
 }
 ```

--- a/vercel.go
+++ b/vercel.go
@@ -26,6 +26,7 @@ func (Provider) CaddyModule() caddy.ModuleInfo {
 func (p *Provider) Provision(ctx caddy.Context) error {
 	repl := caddy.NewReplacer()
 	p.Provider.AuthAPIToken = repl.ReplaceAll(p.Provider.AuthAPIToken, "")
+	p.Provider.TeamId = repl.ReplaceAll(p.Provider.TeamId, "")
 	return nil
 }
 
@@ -37,19 +38,34 @@ func (p *Provider) Provision(ctx caddy.Context) error {
 //
 func (p *Provider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
-		if d.NextArg() {
-			p.Provider.AuthAPIToken = d.Val()
-		}
+		// if d.NextArg() {
+		// 	p.Provider.AuthAPIToken = d.Val()
+		// 	p.Provider.TeamId = d.Val()
+		// }
 		if d.NextArg() {
 			return d.ArgErr()
 		}
 		for nesting := d.Nesting(); d.NextBlock(nesting); {
 			switch d.Val() {
-			case "api_token":
+			case "auth_api_token":
 				if p.Provider.AuthAPIToken != "" {
 					return d.Err("API token already set")
 				}
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
 				p.Provider.AuthAPIToken = d.Val()
+				if d.NextArg() {
+					return d.ArgErr()
+				}
+			case "team_id":
+				if p.Provider.TeamId != "" {
+					return d.Err("team ID already set")
+				}
+				if !d.NextArg() {
+					return d.ArgErr()
+				}
+				p.Provider.TeamId = d.Val()
 				if d.NextArg() {
 					return d.ArgErr()
 				}
@@ -60,6 +76,9 @@ func (p *Provider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	}
 	if p.Provider.AuthAPIToken == "" {
 		return d.Err("missing API token")
+	}
+	if p.Provider.TeamId == "" {
+		return d.Err("missing team ID")
 	}
 	return nil
 }


### PR DESCRIPTION
Vercel has introduced a new team ID that has to be used for accessing resources owned by a team i.e., not part of one's own account. This PR adds support for the team ID.

I have also submitted a PR in libdns/vercel#1 as well which is needed for this to work.

A few things:
- I am just starting to learn Go so you are welcome to make improvements/let me know.
- I don't have any domains in Vercel so cannot test it without the team id parameter